### PR TITLE
Add EdoLift poverty dashboard experience

### DIFF
--- a/apps/bcb-admin/src/pages/Dashboard.tsx
+++ b/apps/bcb-admin/src/pages/Dashboard.tsx
@@ -1,12 +1,6 @@
 import * as React from "react";
-import Card from "@mui/material/Card";
-import CardContent from "@mui/material/CardContent";
-import { Title } from "react-admin";
-const Dashboard = () => (
-  <Card>
-    <Title title="Welcome to the administration" />
-    <CardContent>Welcome</CardContent>
-  </Card>
-);
+import EdoLiftDashboard from "./EdoLiftDashboard";
+
+const Dashboard = () => <EdoLiftDashboard />;
 
 export default Dashboard;

--- a/apps/bcb-admin/src/pages/EdoLift.scss
+++ b/apps/bcb-admin/src/pages/EdoLift.scss
@@ -1,0 +1,868 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
+
+.edo-lift-app {
+  --bg-main: #020617;
+  --bg-panel: rgba(15, 23, 42, 0.98);
+  --bg-chip: rgba(17, 24, 39, 0.9);
+  --border-subtle: rgba(148, 163, 184, 0.35);
+  --accent: #22c55e;
+  --accent-soft: rgba(34, 197, 94, 0.18);
+  --text-main: #e5e7eb;
+  --text-muted: #9ca3af;
+  background: radial-gradient(circle at top left, #0f172a 0, #020617 45%, #020617 100%);
+  color: var(--text-main);
+  min-height: 100vh;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  position: relative;
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+.edo-lift-app.light-mode {
+  --bg-main: #f9fafb;
+  --bg-panel: rgba(255, 255, 255, 0.98);
+  --bg-chip: #f3f4f6;
+  --border-subtle: rgba(209, 213, 219, 0.9);
+  --accent: #16a34a;
+  --accent-soft: rgba(34, 197, 94, 0.12);
+  --text-main: #111827;
+  --text-muted: #4b5563;
+  background: #f9fafb;
+  color: var(--text-main);
+}
+
+.edo-lift-app * {
+  box-sizing: border-box;
+}
+
+.edo-lift-app a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.edo-lift-app ::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.edo-lift-app ::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.edo-lift-app ::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.5);
+  border-radius: 999px;
+}
+
+.edo-lift-app #topHeader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  min-height: 60px;
+  padding: 10px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(15, 23, 42, 0.92);
+  border-bottom: 1px solid var(--border-subtle);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  z-index: 1000;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.9);
+}
+
+.edo-lift-app.light-mode #topHeader {
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 12px 30px rgba(100, 116, 139, 0.25);
+}
+
+.edo-lift-app #brand {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.edo-lift-app #brandTitle {
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.edo-lift-app #brandSubtitle {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.edo-lift-app #headerStats {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.edo-lift-app .statChip {
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: var(--bg-chip);
+  font-size: 0.78rem;
+  white-space: nowrap;
+  color: var(--text-main);
+}
+
+.edo-lift-app #realTimeCounter {
+  border-color: rgba(34, 197, 94, 0.7);
+  background: radial-gradient(circle at top left, var(--accent-soft), var(--bg-chip));
+  box-shadow: 0 8px 20px rgba(34, 197, 94, 0.35);
+}
+
+.edo-lift-app #escapeRate {
+  border-color: rgba(59, 130, 246, 0.7);
+  background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.2), var(--bg-chip));
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.4);
+}
+
+.edo-lift-app #aboutBtn,
+.edo-lift-app #dataModeBtn,
+.edo-lift-app #legacyLink,
+.edo-lift-app #themeToggle {
+  border-color: rgba(148, 163, 184, 0.7);
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.1s ease;
+}
+
+.edo-lift-app #aboutBtn:hover,
+.edo-lift-app #dataModeBtn:hover,
+.edo-lift-app #legacyLink:hover,
+.edo-lift-app #themeToggle:hover {
+  background: rgba(15, 23, 42, 1);
+  transform: translateY(-1px);
+}
+
+.edo-lift-app.light-mode #aboutBtn:hover,
+.edo-lift-app.light-mode #dataModeBtn:hover,
+.edo-lift-app.light-mode #legacyLink:hover,
+.edo-lift-app.light-mode #themeToggle:hover {
+  background: #e5e7eb;
+}
+
+.edo-lift-app #legacyLink {
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.7);
+  font-size: 0.78rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  text-decoration: none;
+}
+
+.edo-lift-app #globalSearch,
+.edo-lift-app #roleSelect {
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.7);
+  background: rgba(15, 23, 42, 0.96);
+  color: var(--text-main);
+  font-size: 0.8rem;
+  outline: none;
+}
+
+.edo-lift-app.light-mode #globalSearch,
+.edo-lift-app.light-mode #roleSelect {
+  background: #f9fafb;
+  border-color: rgba(209, 213, 219, 0.9);
+}
+
+.edo-lift-app #globalSearch::placeholder {
+  color: var(--text-muted);
+}
+
+.edo-lift-app #leftPanel {
+  position: fixed;
+  top: 60px;
+  bottom: 60px;
+  left: 0;
+  width: 290px;
+  padding: 14px 14px 16px;
+  background: var(--bg-panel);
+  border-right: 1px solid var(--border-subtle);
+  box-shadow: 12px 0 30px rgba(15, 23, 42, 0.9);
+  overflow-y: auto;
+  z-index: 800;
+}
+
+.edo-lift-app #rightPanel {
+  position: fixed;
+  top: 60px;
+  bottom: 60px;
+  right: 0;
+  width: 360px;
+  padding: 14px 16px 18px;
+  background: var(--bg-panel);
+  border-left: 1px solid var(--border-subtle);
+  box-shadow: -12px 0 30px rgba(15, 23, 42, 0.9);
+  overflow-y: auto;
+  z-index: 800;
+}
+
+.edo-lift-app #map {
+  position: fixed;
+  top: 60px;
+  left: 290px;
+  right: 360px;
+  bottom: 60px;
+  border-radius: 24px;
+  overflow: hidden;
+  box-shadow: 0 26px 60px rgba(15, 23, 42, 0.95), 0 0 0 1px rgba(15, 23, 42, 0.8);
+  z-index: 500;
+  background: radial-gradient(circle at 20% 20%, rgba(34, 197, 94, 0.08), transparent 35%),
+    radial-gradient(circle at 80% 60%, rgba(56, 189, 248, 0.08), transparent 30%),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.98), rgba(2, 6, 23, 0.9));
+  position: relative;
+}
+
+.edo-lift-app .map-marker {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  background: #22c55e;
+  border: 2px solid #0f172a;
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.25), 0 10px 18px rgba(15, 23, 42, 0.65);
+  transform: translate(-50%, -50%);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.edo-lift-app .map-marker:hover,
+.edo-lift-app .map-marker.active {
+  transform: translate(-50%, -50%) scale(1.1);
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.4), 0 14px 28px rgba(15, 23, 42, 0.75);
+}
+
+.edo-lift-app #runnerCanvas {
+  position: fixed;
+  top: 60px;
+  left: 290px;
+  right: 360px;
+  bottom: 60px;
+  pointer-events: none;
+  z-index: 550;
+}
+
+.edo-lift-app #leftLogo {
+  margin-bottom: 14px;
+}
+
+.edo-lift-app #leftLogo h1 {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.edo-lift-app #leftLogo span {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.edo-lift-app #donutWrapper {
+  padding: 12px 10px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  background: radial-gradient(circle at top left, rgba(34, 197, 94, 0.18), rgba(15, 23, 42, 0.98));
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.9);
+  text-align: center;
+}
+
+.edo-lift-app.light-mode #donutWrapper {
+  background: radial-gradient(circle at top left, rgba(34, 197, 94, 0.18), #ffffff);
+  box-shadow: 0 18px 40px rgba(148, 163, 184, 0.45);
+}
+
+.edo-lift-app #donutWrapper h2 {
+  margin: 0 0 6px;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.edo-lift-app #donutWrapper canvas {
+  max-width: 230px;
+  max-height: 230px;
+  margin: 8px auto 6px;
+}
+
+.edo-lift-app #donutCaption {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.edo-lift-app #timeSliderContainer {
+  margin-top: 14px;
+  padding: 10px 10px 12px;
+  border-radius: 16px;
+  border: 1px solid rgba(75, 85, 99, 0.9);
+  background: rgba(15, 23, 42, 0.98);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.edo-lift-app.light-mode #timeSliderContainer {
+  background: #ffffff;
+  border-color: rgba(209, 213, 219, 0.9);
+}
+
+.edo-lift-app #timeSliderContainer label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+  color: var(--text-muted);
+}
+
+.edo-lift-app #timeSlider {
+  width: 100%;
+  -webkit-appearance: none;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(55, 65, 81, 0.9);
+  outline: none;
+}
+
+.edo-lift-app.light-mode #timeSlider {
+  background: rgba(209, 213, 219, 0.9);
+}
+
+.edo-lift-app #timeSlider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid #111827;
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.3);
+  cursor: pointer;
+}
+
+.edo-lift-app #projectedValue {
+  margin-top: 6px;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.edo-lift-app #premiumStats {
+  margin-bottom: 14px;
+  padding: 14px 14px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  background: radial-gradient(circle at top left, rgba(248, 113, 113, 0.2), var(--bg-panel));
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.9);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.86rem;
+}
+
+.edo-lift-app.light-mode #premiumStats {
+  background: radial-gradient(circle at top left, rgba(248, 113, 113, 0.2), #ffffff);
+  box-shadow: 0 18px 36px rgba(148, 163, 184, 0.4);
+}
+
+.edo-lift-app #premiumStatsHeader {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.edo-lift-app #premiumStatsHeader span.highlight {
+  color: #ef4444;
+  font-weight: 600;
+}
+
+.edo-lift-app #premiumBigNumber {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #ef4444;
+  line-height: 1.1;
+}
+
+.edo-lift-app.light-mode #premiumBigNumber {
+  color: #b91c1c;
+}
+
+.edo-lift-app #premiumCaption {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+.edo-lift-app #premiumSummary {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 6px;
+}
+
+.edo-lift-app #premiumStatInfo {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.edo-lift-app .premium-stat-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.edo-lift-app .premium-stat-item span.icon {
+  font-size: 0.95rem;
+}
+
+.edo-lift-app .premium-stat-item span.number {
+  font-weight: 600;
+  margin-left: 4px;
+  color: var(--text-main);
+}
+
+.edo-lift-app #rightPanel h2 {
+  margin: 0 0 8px;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.edo-lift-app #storyStepper,
+.edo-lift-app #content-trends,
+.edo-lift-app #programPanel,
+.edo-lift-app #africaClockCard {
+  padding: 12px 12px 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(55, 65, 81, 0.9);
+  background: rgba(15, 23, 42, 0.98);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.9);
+  font-size: 0.86rem;
+  margin-bottom: 14px;
+}
+
+.edo-lift-app.light-mode #storyStepper,
+.edo-lift-app.light-mode #content-trends,
+.edo-lift-app.light-mode #programPanel,
+.edo-lift-app.light-mode #africaClockCard {
+  background: #ffffff;
+  border-color: rgba(209, 213, 219, 0.9);
+  box-shadow: 0 18px 36px rgba(148, 163, 184, 0.4);
+}
+
+.edo-lift-app #storyHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.edo-lift-app #storyStepBadge {
+  font-size: 0.75rem;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(31, 41, 55, 0.9);
+  border: 1px solid rgba(55, 65, 81, 0.9);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.edo-lift-app.light-mode #storyStepBadge {
+  background: #f3f4f6;
+  border-color: rgba(209, 213, 219, 0.9);
+}
+
+.edo-lift-app #storyTitle {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.edo-lift-app #storyBody p {
+  margin: 4px 0;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.edo-lift-app #storyBody strong {
+  color: var(--text-main);
+}
+
+.edo-lift-app #storyFooter {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 10px;
+  gap: 8px;
+}
+
+.edo-lift-app #storyScopeLabel {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.edo-lift-app .storyNavBtn {
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(75, 85, 99, 0.9);
+  background: rgba(17, 24, 39, 0.98);
+  color: var(--text-main);
+  font-size: 0.78rem;
+  cursor: pointer;
+  min-width: 90px;
+  transition: background 0.15s ease, transform 0.1s ease, border 0.15s ease;
+}
+
+.edo-lift-app.light-mode .storyNavBtn {
+  background: #f9fafb;
+  border-color: rgba(209, 213, 219, 0.9);
+}
+
+.edo-lift-app .storyNavBtn:hover:not(:disabled) {
+  background: rgba(22, 163, 74, 0.2);
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.edo-lift-app .storyNavBtn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.edo-lift-app #content-trends h3,
+.edo-lift-app #programPanel h3,
+.edo-lift-app #africaClockCard h3 {
+  margin: 0 0 6px;
+  font-size: 0.84rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.edo-lift-app #trendChart {
+  max-height: 220px;
+}
+
+.edo-lift-app #programSummary,
+.edo-lift-app #africaClockText {
+  margin: 4px 0;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.edo-lift-app #filterPanel {
+  position: fixed;
+  left: 270px;
+  right: 340px;
+  bottom: 10px;
+  height: 72px;
+  padding: 6px 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(15, 23, 42, 0.94);
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  box-shadow: 0 18px 42px rgba(15, 23, 42, 1);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  font-size: 0.78rem;
+  z-index: 900;
+  color: var(--text-muted);
+}
+
+.edo-lift-app.light-mode #filterPanel {
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 18px 42px rgba(148, 163, 184, 0.5);
+}
+
+.edo-lift-app #filterPanel label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.edo-lift-app #filterPanel select,
+.edo-lift-app #filterPanel input[type="number"],
+.edo-lift-app #filterPanel input[type="file"] {
+  font-size: 0.78rem;
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(75, 85, 99, 0.9);
+  background: rgba(15, 23, 42, 0.98);
+  color: var(--text-main);
+  outline: none;
+  min-width: 105px;
+}
+
+.edo-lift-app.light-mode #filterPanel select,
+.edo-lift-app.light-mode #filterPanel input[type="number"],
+.edo-lift-app.light-mode #filterPanel input[type="file"] {
+  background: #f9fafb;
+  border-color: rgba(209, 213, 219, 0.9);
+}
+
+.edo-lift-app #filterPanel input[type="number"] {
+  width: 64px;
+}
+
+.edo-lift-app #filterPanel select:focus,
+.edo-lift-app #filterPanel input[type="number"]:focus {
+  border-color: var(--accent);
+}
+
+.edo-lift-app #applyFilters,
+.edo-lift-app #exportCsvBtn,
+.edo-lift-app #exportPdfBtn {
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+  color: #f9fafb;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  box-shadow: 0 8px 18px rgba(34, 197, 94, 0.4);
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+
+.edo-lift-app #applyFilters:hover,
+.edo-lift-app #exportCsvBtn:hover,
+.edo-lift-app #exportPdfBtn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 26px rgba(34, 197, 94, 0.6);
+}
+
+.edo-lift-app #exportCsvBtn,
+.edo-lift-app #exportPdfBtn {
+  background: linear-gradient(135deg, #38bdf8, #0ea5e9);
+  box-shadow: 0 8px 18px rgba(56, 189, 248, 0.4);
+}
+
+.edo-lift-app .modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at top, rgba(15, 23, 42, 0.96), rgba(0, 0, 0, 0.96));
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.edo-lift-app .modalOverlay.open {
+  display: flex;
+}
+
+.edo-lift-app .modal {
+  max-width: 520px;
+  width: 100%;
+  margin: 0 16px;
+  max-height: 80vh;
+  padding: 16px 18px 18px;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: rgba(15, 23, 42, 0.98);
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 1), 0 0 0 1px rgba(15, 23, 42, 0.9);
+  overflow-y: auto;
+  font-size: 0.86rem;
+  color: var(--text-main);
+}
+
+.edo-lift-app.light-mode .modal {
+  background: #ffffff;
+  color: var(--text-main);
+  border-color: rgba(209, 213, 219, 0.9);
+  box-shadow: 0 30px 60px rgba(148, 163, 184, 0.6);
+}
+
+.edo-lift-app .modal h2 {
+  margin-top: 0;
+  font-size: 1rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #d1fae5;
+}
+
+.edo-lift-app.light-mode .modal h2 {
+  color: #16a34a;
+}
+
+.edo-lift-app .modal p {
+  margin: 6px 0;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.edo-lift-app .modal button {
+  margin-top: 10px;
+  padding: 7px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.7);
+  background: rgba(17, 24, 39, 0.98);
+  color: var(--text-main);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.1s ease, border 0.15s ease;
+}
+
+.edo-lift-app.light-mode .modal button {
+  background: #f9fafb;
+  border-color: rgba(209, 213, 219, 0.9);
+}
+
+.edo-lift-app .modal button:hover {
+  background: rgba(22, 163, 74, 0.2);
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.edo-lift-app #methodologyBadge {
+  position: fixed;
+  bottom: 10px;
+  left: 10px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(75, 85, 99, 0.9);
+  background: rgba(15, 23, 42, 0.95);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  z-index: 850;
+}
+
+.edo-lift-app.light-mode #methodologyBadge {
+  background: rgba(255, 255, 255, 0.96);
+  border-color: rgba(209, 213, 219, 0.9);
+  box-shadow: 0 10px 24px rgba(148, 163, 184, 0.5);
+}
+
+.edo-lift-app #methodologyBadge strong {
+  color: var(--text-main);
+}
+
+.edo-lift-app .leaflet-control-zoom a {
+  background: rgba(15, 23, 42, 0.95);
+  color: var(--text-main);
+  border-radius: 10px;
+  border: 1px solid rgba(75, 85, 99, 0.9);
+}
+
+.edo-lift-app.light-mode .leaflet-control-zoom a {
+  background: rgba(255, 255, 255, 0.96);
+  color: #111827;
+  border-color: rgba(209, 213, 219, 0.9);
+}
+
+@media (max-width: 1100px) {
+  .edo-lift-app #rightPanel {
+    width: 320px;
+  }
+
+  .edo-lift-app #map {
+    left: 290px;
+    right: 320px;
+  }
+
+  .edo-lift-app #runnerCanvas {
+    left: 290px;
+    right: 320px;
+  }
+
+  .edo-lift-app #filterPanel {
+    left: 260px;
+    right: 300px;
+  }
+}
+
+@media (max-width: 900px) {
+  .edo-lift-app #leftPanel {
+    width: 260px;
+  }
+
+  .edo-lift-app #rightPanel {
+    width: 280px;
+  }
+
+  .edo-lift-app #map {
+    left: 260px;
+    right: 280px;
+  }
+
+  .edo-lift-app #runnerCanvas {
+    left: 260px;
+    right: 280px;
+  }
+
+  .edo-lift-app #filterPanel {
+    left: 240px;
+    right: 260px;
+  }
+}
+
+@media (max-width: 768px) {
+  .edo-lift-app #leftPanel,
+  .edo-lift-app #rightPanel {
+    width: 100%;
+    max-width: 380px;
+  }
+
+  .edo-lift-app #leftPanel {
+    left: 8px;
+  }
+
+  .edo-lift-app #rightPanel {
+    right: 8px;
+  }
+
+  .edo-lift-app #map {
+    left: 0;
+    right: 0;
+    bottom: 80px;
+    border-radius: 18px;
+  }
+
+  .edo-lift-app #runnerCanvas {
+    left: 0;
+    right: 0;
+    bottom: 80px;
+  }
+
+  .edo-lift-app #filterPanel {
+    left: 8px;
+    right: 8px;
+    bottom: 8px;
+  }
+}
+
+@media (max-width: 640px) {
+  .edo-lift-app #topHeader {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .edo-lift-app #headerStats {
+    justify-content: flex-start;
+  }
+}

--- a/apps/bcb-admin/src/pages/EdoLiftDashboard.tsx
+++ b/apps/bcb-admin/src/pages/EdoLiftDashboard.tsx
@@ -1,0 +1,976 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import "./EdoLift.scss";
+
+const TOTAL_EXTREME_POOR_DEMO = 8000000;
+const PROJECT_DAILY_CHANGE = -500;
+const YEARS_TO_2030 = 5;
+const SECONDS_TO_2030 = YEARS_TO_2030 * 365 * 24 * 3600;
+const BASE_TREND = [8500000, 8300000, 8100000, 8000000, 7900000, 7800000];
+
+const demoPrograms = [
+  { name: "Cash Transfer – Urban Households", lga: "Oredo", district: "Edo South", beneficiaries: 25000, funding: 2000000, status: "ongoing" },
+  { name: "Youth Skills – Green Jobs", lga: "Egor", district: "Edo South", beneficiaries: 12000, funding: 1200000, status: "ongoing" },
+  { name: "Agric Input Support", lga: "Esan West", district: "Edo Central", beneficiaries: 18000, funding: 1500000, status: "ongoing" },
+  { name: "Basic Health Insurance Subsidy", lga: "Etsako West", district: "Edo North", beneficiaries: 15000, funding: 1700000, status: "planned" },
+  { name: "Girls’ Secondary Education Scholarship", lga: "Esan North-East", district: "Edo Central", beneficiaries: 8000, funding: 800000, status: "ongoing" },
+  { name: "Community Infrastructure & Roads", lga: "Akoko-Edo", district: "Edo North", beneficiaries: 10000, funding: 3000000, status: "completed" },
+];
+
+const zones = ["Edo South", "Edo Central", "Edo North"] as const;
+type Zone = (typeof zones)[number];
+
+type DataRow = {
+  lga: string;
+  district: Zone;
+  extremePoor: number;
+  population: number;
+  geography: "Urban" | "Rural" | "Unknown";
+  femaleShare: number;
+};
+
+type Filters = {
+  lgaFilter: string;
+  zoneFilter: "all" | Zone;
+  geoFilter: "all" | "Urban" | "Rural";
+  demoFilter: "all" | "females" | "males";
+  minAge: number;
+  maxAge: number;
+  projectionDays: number;
+  role: "government" | "ngo" | "donor" | "philanthropist" | "public";
+};
+
+type Context = ReturnType<typeof computeContext>;
+
+type SearchItem = { type: "zone" | "lga" | "community" | "indicator" | "programme"; label: string; payload: string };
+
+type ProgramSummary = {
+  text: string;
+  stats: null | {
+    totalBeneficiaries: number;
+    totalFunding: number;
+    ongoing: number;
+    planned: number;
+    completed: number;
+    count: number;
+  };
+};
+
+type MarkerRecord = Record<string, HTMLDivElement>;
+
+const mapBounds = { latMin: 5.8, latMax: 7, lngMin: 4.8, lngMax: 6.8 };
+
+function buildDemoData(): DataRow[] {
+  const demoLgas = [
+    { name: "Oredo", district: "Edo South" as Zone },
+    { name: "Egor", district: "Edo South" as Zone },
+    { name: "Ikpoba-Okha", district: "Edo South" as Zone },
+    { name: "Ovia North-East", district: "Edo South" as Zone },
+    { name: "Ovia South-West", district: "Edo South" as Zone },
+    { name: "Orhionmwon", district: "Edo South" as Zone },
+    { name: "Uhunmwonde", district: "Edo South" as Zone },
+    { name: "Esan Central", district: "Edo Central" as Zone },
+    { name: "Esan North-East", district: "Edo Central" as Zone },
+    { name: "Esan South-East", district: "Edo Central" as Zone },
+    { name: "Esan West", district: "Edo Central" as Zone },
+    { name: "Igueben", district: "Edo Central" as Zone },
+    { name: "Akoko-Edo", district: "Edo North" as Zone },
+    { name: "Etsako Central", district: "Edo North" as Zone },
+    { name: "Etsako East", district: "Edo North" as Zone },
+    { name: "Etsako West", district: "Edo North" as Zone },
+    { name: "Owan East", district: "Edo North" as Zone },
+    { name: "Owan West", district: "Edo North" as Zone },
+  ];
+
+  const zoneCounts: Record<Zone, number> = {
+    "Edo South": 0,
+    "Edo Central": 0,
+    "Edo North": 0,
+  };
+  demoLgas.forEach((lga) => {
+    zoneCounts[lga.district] += 1;
+  });
+
+  const perZone = TOTAL_EXTREME_POOR_DEMO / 3;
+
+  return demoLgas.map((lga) => {
+    const extreme = Math.floor(perZone / zoneCounts[lga.district]);
+    const population = Math.round(extreme / 0.7);
+    const geography = lga.district === "Edo South" ? "Urban" : "Rural";
+    const femaleShare = lga.district === "Edo Central" ? 0.52 : 0.5;
+    return {
+      lga: lga.name,
+      district: lga.district,
+      extremePoor: extreme,
+      population,
+      geography,
+      femaleShare,
+    };
+  });
+}
+
+function computeAgeFactor(minAge: number, maxAge: number) {
+  let factor = 0;
+  if (minAge <= 17 && maxAge >= 0) factor += 0.25;
+  if (minAge <= 64 && maxAge >= 18) factor += 0.6;
+  if (minAge <= 100 && maxAge >= 65) factor += 0.15;
+  return Math.min(1, factor);
+}
+
+function getScopeLabel(lgaFilter: string, zoneFilter: Filters["zoneFilter"]) {
+  if (lgaFilter !== "all") return `${lgaFilter} LGA`;
+  if (zoneFilter !== "all") return `${zoneFilter} Senatorial Zone`;
+  return "Edo State (all LGAs)";
+}
+
+function sumExtremePoor(rows: DataRow[]) {
+  return rows.reduce((acc, r) => acc + (r.extremePoor || 0), 0);
+}
+
+function computeContext(rows: DataRow[], filters: Filters) {
+  const { lgaFilter, zoneFilter, geoFilter, demoFilter, minAge, maxAge, projectionDays, role } = filters;
+  const ageFactor = computeAgeFactor(minAge, maxAge);
+
+  let totalPoor = 0;
+  let totalPop = 0;
+  const zoneTotals: Record<Zone, number> = { "Edo South": 0, "Edo Central": 0, "Edo North": 0 };
+
+  rows.forEach((row) => {
+    if (lgaFilter !== "all" && row.lga !== lgaFilter) return;
+    if (zoneFilter !== "all" && row.district !== zoneFilter) return;
+    if (geoFilter !== "all" && row.geography !== geoFilter) return;
+
+    let genderFactor = 1;
+    if (demoFilter === "females") genderFactor = row.femaleShare || 0.5;
+    else if (demoFilter === "males") genderFactor = 1 - (row.femaleShare || 0.5);
+
+    const factor = genderFactor * ageFactor;
+    const lgaPoor = (row.extremePoor || 0) * factor;
+    const lgaPop = (row.population || 0) * factor;
+
+    totalPoor += lgaPoor;
+    totalPop += lgaPop;
+    zoneTotals[row.district] += lgaPoor;
+  });
+
+  if (totalPop <= 0) totalPop = 1;
+  const povertyRate = totalPoor > 0 ? totalPoor / totalPop : 0;
+
+  let highestZone: Zone = "Edo South";
+  let highestZonePoor = 0;
+  (Object.keys(zoneTotals) as Zone[]).forEach((z) => {
+    if (zoneTotals[z] > highestZonePoor) {
+      highestZonePoor = zoneTotals[z];
+      highestZone = z;
+    }
+  });
+
+  const highestZoneShare = totalPoor > 0 ? highestZonePoor / totalPoor : 0;
+  const projectedPoorRaw = totalPoor + projectionDays * PROJECT_DAILY_CHANGE;
+  const projectedPoor = projectedPoorRaw > 0 ? projectedPoorRaw : 0;
+  const projectedRate = projectedPoor / totalPop;
+
+  const targetPoor = 0.03 * totalPop;
+  const peopleToLift = totalPoor > targetPoor ? totalPoor - targetPoor : 0;
+  const requiredRatePerSecond = peopleToLift > 0 ? peopleToLift / SECONDS_TO_2030 : 0;
+
+  const scopeLabel = getScopeLabel(lgaFilter, zoneFilter);
+  const exampleRow = lgaFilter !== "all" ? rows.find((r) => r.lga === lgaFilter) : rows.find((r) => r.district === highestZone) || rows[0];
+
+  return {
+    ...filters,
+    totalPoor: Math.round(totalPoor),
+    totalPop: Math.round(totalPop),
+    povertyRate,
+    projectedPoor: Math.round(projectedPoor),
+    projectedRate,
+    highestZone,
+    highestZoneShare,
+    scopeLabel,
+    targetPoor: Math.round(targetPoor),
+    peopleToLift: Math.round(peopleToLift),
+    requiredRatePerSecond,
+    exampleLga: exampleRow ? exampleRow.lga : "Oredo",
+  };
+}
+
+function rolePerspective(role: Filters["role"], scopeLabel: string) {
+  switch (role) {
+    case "government":
+      return `For government planners, this view can guide <strong>budget prioritisation, social protection expansion</strong> and SDG-aligned planning across <strong>${scopeLabel}</strong>.`;
+    case "ngo":
+      return `For NGOs and CSOs, the data highlights where to <strong>target projects, advocacy, and community engagement</strong> within <strong>${scopeLabel}</strong>.`;
+    case "donor":
+      return `For donors and development partners, this view helps align <strong>funding envelopes, programme pipelines</strong> and results frameworks with <strong>${scopeLabel}</strong>.`;
+    case "philanthropist":
+      return `For philanthropists, the numbers reveal where <strong>flexible capital</strong> can unlock the greatest impact in <strong>${scopeLabel}</strong>.`;
+    case "public":
+    default:
+      return `For the general public, this view improves <strong>transparency, accountability</strong> and understanding of poverty challenges in <strong>${scopeLabel}</strong>.`;
+  }
+}
+
+const storySteps = [
+  {
+    title: "Where are we today?",
+    render: (ctx: Context) =>
+      `<p>Within <strong>${ctx.scopeLabel}</strong>, we estimate about <strong>${ctx.totalPoor.toLocaleString()}</strong> people in extreme poverty. That is roughly <strong>${(ctx.povertyRate * 100).toFixed(1)}%</strong> of the filtered population.</p><p>The largest simulated burden sits in <strong>${ctx.highestZone}</strong>, accounting for about <strong>${(ctx.highestZoneShare * 100).toFixed(1)}%</strong> of extreme poor in this view.</p><p>${rolePerspective(ctx.role, ctx.scopeLabel)}</p>`,
+  },
+  {
+    title: "Who is being left behind?",
+    render: (ctx: Context) => {
+      let demographicText = "You are looking at <strong>all genders</strong>.";
+      if (ctx.demoFilter === "females") demographicText = "You are focusing on <strong>women and girls</strong>.";
+      if (ctx.demoFilter === "males") demographicText = "You are focusing on <strong>men and boys</strong>.";
+
+      let geoText = "Both urban and rural areas are included.";
+      if (ctx.geoFilter === "Urban") geoText = "This view emphasises <strong>urban poverty hotspots</strong>.";
+      if (ctx.geoFilter === "Rural") geoText = "This view emphasises <strong>rural communities</strong>.";
+
+      const ageText = ctx.minAge === 0 && ctx.maxAge === 100 ? "All age groups are included." : `The age window is set to <strong>${ctx.minAge}–${ctx.maxAge} years</strong>.`;
+
+      return `<p>${demographicText} ${geoText} ${ageText}</p><p>Under these filters, programmes that combine <strong>income support, basic services, and livelihoods</strong> in <strong>${ctx.highestZone}</strong> could move the largest number of people out of extreme poverty.</p><p>${rolePerspective(ctx.role, ctx.scopeLabel)}</p>`;
+    },
+  },
+  {
+    title: "Are we on track for SDG 1?",
+    render: (ctx: Context) => {
+      const rate = ctx.requiredRatePerSecond;
+      const readableRate = rate > 0 ? `${rate.toFixed(2)} people per second` : "no additional people (target already reached in this view)";
+      return `<p>To reduce extreme poverty in <strong>${ctx.scopeLabel}</strong> below <strong>3%</strong> by 2030, about <strong>${ctx.peopleToLift.toLocaleString()}</strong> people need to escape extreme poverty in the next <strong>${YEARS_TO_2030} years</strong>.</p><p>That translates into lifting roughly <strong>${readableRate}</strong> out of extreme poverty under this simple trajectory.</p><p>This connects directly to the <strong>Africa Poverty Clock</strong> module, where Edo State’s SDG 1 progress can be compared against Nigeria and other African peers.</p>`;
+    },
+  },
+  {
+    title: "What policy mix is implied?",
+    render: (ctx: Context) =>
+      `<p>Given this burden and trajectory, <strong>${ctx.scopeLabel}</strong> would benefit from a balanced policy mix:</p><p>• <strong>Short-term shock response</strong> – cash or food support to stabilise households currently in extreme poverty (${ctx.totalPoor.toLocaleString()} people).</p><p>• <strong>Medium-term productivity</strong> – skills, jobs and enterprise programmes targeted to LGAs such as <strong>${ctx.exampleLga}</strong> in ${ctx.highestZone}.</p><p>• <strong>System reforms</strong> – investments in health, education and connectivity to keep future cohorts from falling into poverty.</p><p>${rolePerspective(ctx.role, ctx.scopeLabel)}</p>`,
+  },
+];
+
+function parseCsv(text: string): DataRow[] {
+  const lines = text.trim().split(/\r?\n/);
+  if (lines.length < 2) return [];
+
+  const headers = lines[0].split(",").map((h) => h.trim().toLowerCase());
+  const rows: DataRow[] = [];
+
+  for (let i = 1; i < lines.length; i += 1) {
+    if (!lines[i].trim()) continue;
+    const cells = lines[i].split(",").map((c) => c.trim());
+    const rowObj: Record<string, string> = {};
+    headers.forEach((h, idx) => {
+      rowObj[h] = cells[idx];
+    });
+
+    const lga = rowObj["lga"] || rowObj["lga_name"] || "";
+    const district = (rowObj["district"] || rowObj["zone"] || "") as Zone;
+    const extreme = parseInt(rowObj["extreme_poor"] || rowObj["extreme"] || rowObj["poverty"] || "0", 10) || 0;
+    const population = parseInt(rowObj["population"] || "0", 10) || 0;
+    const geography = (rowObj["geography"] || rowObj["geo"] || "Unknown") as DataRow["geography"];
+    const femaleShare = parseFloat(rowObj["female_share"] || "0.5") || 0.5;
+
+    if (!lga || !district) continue;
+
+    rows.push({
+      lga,
+      district,
+      extremePoor: extreme,
+      population: population > 0 ? population : Math.round(extreme / 0.7),
+      geography: geography === "Urban" || geography === "Rural" ? geography : "Unknown",
+      femaleShare,
+    });
+  }
+
+  return rows;
+}
+
+function buildSearchIndex(rows: DataRow[]): SearchItem[] {
+  const index: SearchItem[] = [];
+  zones.forEach((z) => index.push({ type: "zone", label: z, payload: z }));
+
+  const lgaSet = new Set<string>();
+  rows.forEach((r) => {
+    if (!lgaSet.has(r.lga)) {
+      lgaSet.add(r.lga);
+      index.push({ type: "lga", label: r.lga, payload: r.lga });
+    }
+  });
+
+  ["Benin City", "Uromi", "Auchi", "Igarra", "Sabongida-Ora"].forEach((c) => index.push({ type: "community", label: c, payload: c }));
+
+  ["Poverty rate", "Extreme poverty headcount", "Inequality (Gini)", "Multidimensional poverty", "Escape rate"].forEach((ind) =>
+    index.push({ type: "indicator", label: ind, payload: ind })
+  );
+
+  ["Cash transfers", "Youth skills initiative", "Agric support programme", "Health insurance subsidy"].forEach((p) =>
+    index.push({ type: "programme", label: p, payload: p })
+  );
+
+  return index;
+}
+
+function calculateProgramSummary(ctx: Context | null): ProgramSummary {
+  if (!ctx) {
+    return {
+      text: "Loading programme data…",
+      stats: null,
+    };
+  }
+
+  let filtered = demoPrograms;
+  if (ctx.lgaFilter !== "all") {
+    filtered = filtered.filter((p) => p.lga === ctx.lgaFilter);
+  } else if (ctx.zoneFilter !== "all") {
+    filtered = filtered.filter((p) => p.district === ctx.zoneFilter);
+  }
+
+  if (filtered.length === 0) {
+    return {
+      text: "No demo programmes are mapped to this filtered view yet. In production, this section will track funding flows, beneficiaries and programme status for all poverty-alleviation interventions.",
+      stats: null,
+    };
+  }
+
+  const totalBeneficiaries = filtered.reduce((acc, p) => acc + p.beneficiaries, 0);
+  const totalFunding = filtered.reduce((acc, p) => acc + p.funding, 0);
+  const ongoing = filtered.filter((p) => p.status === "ongoing").length;
+  const planned = filtered.filter((p) => p.status === "planned").length;
+  const completed = filtered.filter((p) => p.status === "completed").length;
+
+  return {
+    text: `Estimated beneficiaries: ${totalBeneficiaries.toLocaleString()} | Funding: $${totalFunding.toLocaleString()} | Status: ${ongoing} ongoing, ${planned} planned, ${completed} completed.`,
+    stats: { totalBeneficiaries, totalFunding, ongoing, planned, completed, count: filtered.length },
+  };
+}
+
+function latLngToPoint(lat: number, lng: number, container: HTMLElement) {
+  const { latMin, latMax, lngMin, lngMax } = mapBounds;
+  const x = ((lng - lngMin) / (lngMax - lngMin)) * container.clientWidth;
+  const y = ((latMax - lat) / (latMax - latMin)) * container.clientHeight;
+  return { x, y };
+}
+
+function drawDonut(canvas: HTMLCanvasElement, ratePercent: number) {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  const size = Math.min(canvas.parentElement?.clientWidth || 240, 240);
+  canvas.width = size;
+  canvas.height = size;
+  const center = size / 2;
+  const radius = size / 2 - 12;
+  const startAngle = -Math.PI / 2;
+  const povertyAngle = (ratePercent / 100) * Math.PI * 2;
+
+  ctx.clearRect(0, 0, size, size);
+  ctx.lineWidth = 18;
+  ctx.strokeStyle = "#020617";
+  ctx.beginPath();
+  ctx.arc(center, center, radius, 0, Math.PI * 2);
+  ctx.stroke();
+
+  ctx.strokeStyle = "#22c55e";
+  ctx.beginPath();
+  ctx.arc(center, center, radius, startAngle, startAngle + povertyAngle);
+  ctx.stroke();
+
+  ctx.fillStyle = "#e5e7eb";
+  ctx.font = "700 18px Inter, system-ui";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText(`${ratePercent.toFixed(1)}%`, center, center);
+}
+
+function drawTrend(canvas: HTMLCanvasElement, data: number[]) {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  const width = canvas.parentElement?.clientWidth || 320;
+  const height = 220;
+  canvas.width = width;
+  canvas.height = height;
+
+  const maxVal = Math.max(...data, 1);
+  const minVal = Math.min(...data, 0);
+  const padding = 20;
+  const points = data.map((v, idx) => {
+    const x = padding + (idx / Math.max(data.length - 1, 1)) * (width - padding * 2);
+    const y = height - padding - ((v - minVal) / (maxVal - minVal)) * (height - padding * 2);
+    return { x, y };
+  });
+
+  ctx.clearRect(0, 0, width, height);
+  ctx.strokeStyle = "rgba(255,255,255,0.08)";
+  ctx.lineWidth = 1;
+  points.forEach((p) => {
+    ctx.beginPath();
+    ctx.moveTo(p.x, padding);
+    ctx.lineTo(p.x, height - padding);
+    ctx.stroke();
+  });
+
+  ctx.strokeStyle = "#22c55e";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  points.forEach((p, idx) => {
+    if (idx === 0) ctx.moveTo(p.x, p.y);
+    else ctx.lineTo(p.x, p.y);
+  });
+  ctx.stroke();
+
+  ctx.fillStyle = "#22c55e";
+  points.forEach((p) => {
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, 3, 0, Math.PI * 2);
+    ctx.fill();
+  });
+}
+
+function EdoLiftDashboard() {
+  const [dataMode, setDataMode] = useState<"demo" | "csv">("demo");
+  const [rawRows, setRawRows] = useState<DataRow[]>(() => buildDemoData());
+  const [pendingFilters, setPendingFilters] = useState<Filters>({
+    lgaFilter: "all",
+    zoneFilter: "all",
+    geoFilter: "all",
+    demoFilter: "all",
+    minAge: 0,
+    maxAge: 100,
+    projectionDays: 0,
+    role: "government",
+  });
+  const [filters, setFilters] = useState<Filters>(pendingFilters);
+  const [searchValue, setSearchValue] = useState("");
+  const [storyIndex, setStoryIndex] = useState(0);
+  const [theme, setTheme] = useState<"dark" | "light">("dark");
+
+  const mapContainerRef = useRef<HTMLDivElement | null>(null);
+  const runnerCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const pieCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const trendCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const markersRef = useRef<MarkerRecord>({});
+  const animationRef = useRef<number | null>(null);
+
+  const context = useMemo(() => (rawRows.length ? computeContext(rawRows, filters) : null), [filters, rawRows]);
+  const searchIndex = useMemo(() => buildSearchIndex(rawRows), [rawRows]);
+  const programSummary = useMemo(() => calculateProgramSummary(context), [context]);
+
+  useEffect(() => {
+    const container = mapContainerRef.current;
+    if (!container) return;
+    container.innerHTML = "";
+    markersRef.current = {};
+
+    const fragment = document.createDocumentFragment();
+    rawRows.forEach((row, idx) => {
+      const rowIdx = Math.floor(idx / 3);
+      const col = idx % 3;
+      const lat = 6.1 + rowIdx * 0.25;
+      const lng = 5.2 + col * 0.45;
+      const marker = document.createElement("div");
+      marker.className = "map-marker";
+      marker.title = `${row.lga} (${row.district})`;
+      marker.dataset.lga = row.lga;
+      fragment.appendChild(marker);
+      markersRef.current[row.lga] = marker;
+
+      requestAnimationFrame(() => {
+        const { x, y } = latLngToPoint(lat, lng, container);
+        marker.style.left = `${x}px`;
+        marker.style.top = `${y}px`;
+      });
+    });
+    container.appendChild(fragment);
+  }, [rawRows]);
+
+  useEffect(() => {
+    const canvas = runnerCanvasRef.current;
+    const container = mapContainerRef.current;
+    if (!canvas || !container || !context) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const handleResize = () => {
+      canvas.width = container.clientWidth;
+      canvas.height = container.clientHeight;
+      canvas.style.left = `${container.getBoundingClientRect().left}px`;
+      canvas.style.top = `${container.getBoundingClientRect().top}px`;
+    };
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+
+    const runners = rawRows.map((row, index) => {
+      const marker = markersRef.current[row.lga];
+      const rect = marker?.getBoundingClientRect();
+      const containerRect = container.getBoundingClientRect();
+      const point = rect
+        ? { x: rect.left - containerRect.left + rect.width / 2, y: rect.top - containerRect.top + rect.height / 2 }
+        : { x: 20 + index * 12, y: 20 + index * 8 };
+      return {
+        lga: row.lga,
+        startX: point.x,
+        endX: point.x + (index % 2 === 0 ? 80 : -80),
+        y: point.y,
+        duration: 7000,
+        delay: index * 400,
+        startTime: 0,
+        directionOut: index % 2 === 0,
+      };
+    });
+
+    const draw = (timestamp: number) => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      runners.forEach((runner) => {
+        if (!runner.startTime) runner.startTime = timestamp + runner.delay;
+        if (timestamp < runner.startTime) return;
+        const t = (timestamp - runner.startTime) / runner.duration;
+        if (t >= 1) {
+          runner.startTime = timestamp + runner.delay;
+          return;
+        }
+        const x = runner.startX + (runner.endX - runner.startX) * t;
+        ctx.fillStyle = runner.directionOut ? "#22c55e" : "#ef4444";
+        ctx.beginPath();
+        ctx.arc(x, runner.y, 6, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.fillStyle = "#111827";
+        ctx.font = "10px Inter, system-ui";
+        ctx.textAlign = "center";
+        ctx.fillText(runner.lga, x, runner.y - 12);
+      });
+      animationRef.current = requestAnimationFrame(draw);
+    };
+
+    animationRef.current = requestAnimationFrame(draw);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      if (animationRef.current) cancelAnimationFrame(animationRef.current);
+    };
+  }, [rawRows, context]);
+
+  useEffect(() => {
+    if (!context) return;
+    if (pieCanvasRef.current) {
+      const ratePercent = Math.max(0, Math.min(100, context.povertyRate * 100));
+      drawDonut(pieCanvasRef.current, ratePercent);
+    }
+    if (trendCanvasRef.current) {
+      const stateTotal = dataMode === "demo" ? TOTAL_EXTREME_POOR_DEMO : sumExtremePoor(rawRows);
+      const scale = stateTotal > 0 ? context.totalPoor / stateTotal : 0;
+      const scaledTrend = BASE_TREND.map((v) => Math.round(v * scale));
+      drawTrend(trendCanvasRef.current, scaledTrend);
+    }
+
+    const container = mapContainerRef.current;
+    if (container) {
+      Object.values(markersRef.current).forEach((el) => el.classList.remove("active"));
+      if (context.lgaFilter !== "all" && markersRef.current[context.lgaFilter]) {
+        markersRef.current[context.lgaFilter].classList.add("active");
+      }
+    }
+  }, [context, dataMode, rawRows]);
+
+  const handleApplyFilters = () => {
+    setStoryIndex(0);
+    setFilters(pendingFilters);
+  };
+
+  const handleSearch = () => {
+    const q = searchValue.toLowerCase().replace(/\(.*?\)$/, "").trim();
+    if (!q) return;
+    let match = searchIndex.find((item) => item.label.toLowerCase() === q);
+    if (!match) match = searchIndex.find((item) => item.label.toLowerCase().startsWith(q));
+    if (!match) return;
+
+    if (match.type === "lga") {
+      setPendingFilters((prev) => ({ ...prev, lgaFilter: match.payload, zoneFilter: "all" }));
+      setFilters((prev) => ({ ...prev, lgaFilter: match.payload, zoneFilter: "all" }));
+    } else if (match.type === "zone") {
+      setPendingFilters((prev) => ({ ...prev, zoneFilter: match.payload as Zone, lgaFilter: "all" }));
+      setFilters((prev) => ({ ...prev, zoneFilter: match.payload as Zone, lgaFilter: "all" }));
+    } else if (match.type === "community") {
+      let zone: Zone = "Edo South";
+      if (["Uromi"].includes(match.payload)) zone = "Edo Central";
+      if (["Auchi", "Igarra", "Sabongida-Ora"].includes(match.payload)) zone = "Edo North";
+      setPendingFilters((prev) => ({ ...prev, zoneFilter: zone, lgaFilter: "all" }));
+      setFilters((prev) => ({ ...prev, zoneFilter: zone, lgaFilter: "all" }));
+    } else if (match.type === "indicator") {
+      setStoryIndex(1);
+    } else if (match.type === "programme") {
+      setStoryIndex(3);
+    }
+  };
+
+  const handleCsvUpload = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      const text = event.target?.result as string;
+      const rows = parseCsv(text);
+      if (!rows.length) return;
+      setDataMode("csv");
+      setRawRows(rows);
+      setFilters({ ...pendingFilters, lgaFilter: "all", zoneFilter: "all" });
+      setPendingFilters((prev) => ({ ...prev, lgaFilter: "all", zoneFilter: "all" }));
+    };
+    reader.readAsText(file);
+  };
+
+  const exportFilteredCsv = () => {
+    if (!context) return;
+    const ageFactor = computeAgeFactor(context.minAge, context.maxAge);
+    const rowsOut = rawRows
+      .map((row) => {
+        if (context.lgaFilter !== "all" && row.lga !== context.lgaFilter) return null;
+        if (context.zoneFilter !== "all" && row.district !== context.zoneFilter) return null;
+        if (context.geoFilter !== "all" && row.geography !== context.geoFilter) return null;
+
+        let genderFactor = 1;
+        if (context.demoFilter === "females") genderFactor = row.femaleShare || 0.5;
+        else if (context.demoFilter === "males") genderFactor = 1 - (row.femaleShare || 0.5);
+        const factor = genderFactor * ageFactor;
+        return {
+          lga: row.lga,
+          district: row.district,
+          geography: row.geography,
+          extremePoorFiltered: Math.round((row.extremePoor || 0) * factor),
+          populationFiltered: Math.round((row.population || 0) * factor),
+        };
+      })
+      .filter(Boolean) as { lga: string; district: string; geography: string; extremePoorFiltered: number; populationFiltered: number }[];
+
+    if (!rowsOut.length) return;
+
+    let csv = "LGA,District,Geography,ExtremePoorFiltered,PopulationFiltered\n";
+    rowsOut.forEach((r) => {
+      csv += `${r.lga},${r.district},${r.geography},${r.extremePoorFiltered},${r.populationFiltered}\n`;
+    });
+
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.setAttribute("download", "edolift_filtered_export.csv");
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const exportPdfBrief = () => {
+    if (!context) return;
+    const stepHtml = storySteps.map((step, idx) => `<h3>Step ${idx + 1}: ${step.title}</h3>${step.render(context)}`).join("<hr>");
+
+    const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>EdoLift SDG1 Brief</title><style>body { font-family: Arial, sans-serif; padding: 20px; line-height: 1.6; } h1, h2, h3 { color: #111827; } h1 { font-size: 20px; } h2 { font-size: 16px; margin-top: 20px; } h3 { font-size: 14px; margin-top: 15px; } p { font-size: 12px; } hr { margin: 16px 0; border: none; border-top: 1px solid #e5e7eb; } .meta { font-size: 11px; color: #6b7280; margin-bottom: 12px; }</style></head><body><h1>EdoLift SDG 1 – Poverty & Equity Brief</h1><div class="meta">Scope: ${context.scopeLabel}<br>Data mode: ${dataMode === "demo" ? "Demo (synthetic)" : "CSV/API (real dataset)"}<br>Role perspective: ${context.role}</div><h2>Key numbers</h2><p>Extreme poor (filtered): <strong>${context.totalPoor.toLocaleString()}</strong><br>Filtered population: <strong>${context.totalPop.toLocaleString()}</strong><br>Poverty rate: <strong>${(context.povertyRate * 100).toFixed(1)}%</strong><br>People to lift to reach &lt;3%: <strong>${context.peopleToLift.toLocaleString()}</strong></p><h2>Narrative storyline</h2>${stepHtml}</body></html>`;
+
+    const win = window.open("", "_blank");
+    if (!win) return;
+    win.document.write(html);
+    win.document.close();
+    win.focus();
+    win.print();
+  };
+
+  const premiumSummaryText = context
+    ? context.peopleToLift <= 0
+      ? "In this filtered view, SDG 1 (<3% in extreme poverty) is already achieved."
+      : `${context.peopleToLift.toLocaleString()} people still need to escape extreme poverty to reach the SDG 1 goal (<3%) in this view.`
+    : "Loading SDG1 gap…";
+
+  const africaClockText = context
+    ? `<p>This simplified Africa Poverty Clock view estimates that in <strong>${context.scopeLabel}</strong>, about <strong>${context.totalPoor.toLocaleString()}</strong> people are in extreme poverty under current filters.</p><p>To reach the SDG 1 target (&lt;3%) by 2030, approximately <strong>${context.peopleToLift.toLocaleString()}</strong> people still need to be lifted out of extreme poverty.</p><p>This implies a required pace of about <strong>${context.requiredRatePerSecond.toFixed(2)} people per second</strong>. ${context.peopleToLift <= 0 ? "On track or already below the SDG 1 threshold in this view." : "Needs to accelerate exits from extreme poverty to match SDG 1 expectations."}</p>`
+    : "Loading Africa Poverty Clock view…";
+
+  return (
+    <div className={`edo-lift-app ${theme === "light" ? "light-mode" : ""}`}>
+      <header id="topHeader">
+        <div id="brand">
+          <div id="brandTitle">EdoLift · SDG 1</div>
+          <div id="brandSubtitle">Poverty Alleviation Management Platform for Edo State</div>
+        </div>
+        <div id="headerStats">
+          <div className="input-wrapper">
+            <input
+              id="globalSearch"
+              type="search"
+              placeholder="Search LGAs, zones, indicators, programmes…"
+              value={searchValue}
+              onChange={(e) => setSearchValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleSearch();
+              }}
+              list="searchSuggestions"
+            />
+            <datalist id="searchSuggestions">
+              {searchIndex.map((item) => (
+                <option key={`${item.type}-${item.label}`} value={`${item.label} (${item.type})`} />
+              ))}
+            </datalist>
+          </div>
+
+          <select
+            id="roleSelect"
+            value={pendingFilters.role}
+            onChange={(e) => {
+              const role = e.target.value as Filters["role"];
+              setPendingFilters((prev) => ({ ...prev, role }));
+              setFilters((prev) => ({ ...prev, role }));
+            }}
+          >
+            <option value="government">Government planner</option>
+            <option value="ngo">NGO / CSO</option>
+            <option value="donor">Donor / development partner</option>
+            <option value="philanthropist">Philanthropist</option>
+            <option value="public">Citizen / public</option>
+          </select>
+
+          <a id="legacyLink" href="datas.html" target="_blank" rel="noreferrer" title="Open the original EdoLift map view">
+            Classic Map View
+          </a>
+
+          <div id="realTimeCounter" className="statChip">
+            {context ? `${context.totalPoor.toLocaleString()} in extreme poverty (${(context.povertyRate * 100).toFixed(1)} of filtered scope)` : "Loading poverty numbers…"}
+          </div>
+          <div id="escapeRate" className="statChip">
+            {context
+              ? context.peopleToLift <= 0
+                ? "In this view, SDG 1 (<3%) is already met."
+                : `To hit <3% by 2030: lift ${context.requiredRatePerSecond.toFixed(2)}/sec (${Math.round(context.requiredRatePerSecond * 86400).toLocaleString()}/day)`
+              : "Calculating SDG 1 trajectory…"}
+          </div>
+          <button
+            id="dataModeBtn"
+            className="statChip"
+            type="button"
+            onClick={() => {
+              if (dataMode === "demo") return;
+              setDataMode("demo");
+              setRawRows(buildDemoData());
+            }}
+          >
+            Data mode: {dataMode === "demo" ? "Demo" : "CSV"}
+          </button>
+          <button id="themeToggle" className="statChip" type="button" onClick={() => setTheme((prev) => (prev === "dark" ? "light" : "dark"))}>
+            {theme === "dark" ? "Light mode" : "Dark mode"}
+          </button>
+          <button
+            id="aboutBtn"
+            className="statChip"
+            type="button"
+            onClick={() => {
+              const modal = document.getElementById("aboutModal");
+              if (modal) modal.classList.add("open");
+            }}
+          >
+            About &amp; methodology
+          </button>
+        </div>
+      </header>
+
+      <aside id="leftPanel">
+        <div id="leftLogo">
+          <h1>Edo Poverty Atlas</h1>
+          <span>Real-time dashboard, deep dives, and forecasts through 2030</span>
+        </div>
+
+        <section id="donutWrapper">
+          <h2>Extreme poverty share</h2>
+          <canvas ref={pieCanvasRef} />
+          <p id="donutCaption">Share of population in extreme poverty under current filters.</p>
+        </section>
+
+        <section id="timeSliderContainer">
+          <label htmlFor="timeSlider">
+            Projection window
+            <span id="timeSliderDays">{filters.projectionDays} days</span>
+          </label>
+          <input
+            type="range"
+            id="timeSlider"
+            min="0"
+            max="365"
+            value={pendingFilters.projectionDays}
+            onChange={(e) => setPendingFilters((prev) => ({ ...prev, projectionDays: Number(e.target.value) }))}
+            onMouseUp={() => setFilters((prev) => ({ ...prev, projectionDays: pendingFilters.projectionDays }))}
+            onTouchEnd={() => setFilters((prev) => ({ ...prev, projectionDays: pendingFilters.projectionDays }))}
+          />
+          <div id="projectedValue">
+            {context ? (
+              pendingFilters.projectionDays === 0 ? (
+                "No projection applied. Move the slider to explore how a simple linear trend changes the numbers."
+              ) : (
+                `In ${pendingFilters.projectionDays} days, this simple linear trajectory would lead to about ${context.projectedPoor.toLocaleString()} people in extreme poverty (${(context.projectedRate * 100).toFixed(1)}%), ${Math.abs(context.projectedPoor - context.totalPoor).toLocaleString()} ${
+                  context.projectedPoor - context.totalPoor < 0 ? "fewer" : "more"
+                } than today.`
+              )
+            ) : (
+              "Move the slider to see a simple projection on the current trajectory."
+            )}
+          </div>
+        </section>
+      </aside>
+
+      <div id="map" ref={mapContainerRef} aria-label="Map of LGAs in Edo State" />
+      <canvas id="runnerCanvas" ref={runnerCanvasRef} aria-hidden="true" />
+
+      <aside id="rightPanel">
+        <section id="premiumStats">
+          <div id="premiumStatsHeader">
+            <span>EDO POVERTY SNAPSHOT (DEMO)</span>
+            <span className="highlight">
+              <span id="premiumPercent">{context ? `${(context.povertyRate * 100).toFixed(1)}%` : "7.6%"}</span> in extreme poverty
+            </span>
+          </div>
+          <div id="premiumBigNumber">{context ? context.totalPoor.toLocaleString() : "612,692,759"}</div>
+          <div id="premiumCaption">people in this filtered view living in extreme poverty</div>
+          <div id="premiumSummary">{premiumSummaryText}</div>
+          <div id="premiumStatInfo">
+            <div className="premium-stat-item">
+              <span className="icon">✅</span>
+              <span>Target escape rate</span>
+              <span className="number" id="premiumTargetRate">{context ? `${context.requiredRatePerSecond.toFixed(2)} people/sec` : "3.54 people/sec"}</span>
+            </div>
+            <div className="premium-stat-item">
+              <span className="icon">🚨</span>
+              <span>Current escape rate (demo)</span>
+              <span className="number" id="premiumCurrentRate">{(Math.abs(PROJECT_DAILY_CHANGE) / 86400).toFixed(2)} people/sec</span>
+            </div>
+            <div className="premium-stat-item">
+              <span className="icon">🏃</span>
+              <span>Escaped poverty today (demo)</span>
+              <span className="number" id="premiumEscapedToday">12,546</span>
+            </div>
+            <div className="premium-stat-item">
+              <span className="icon">📉</span>
+              <span>Fell into poverty today (demo)</span>
+              <span className="number" id="premiumFellToday">11,058</span>
+            </div>
+          </div>
+        </section>
+
+        <h2>SDG 1 storyline</h2>
+        <section id="storyStepper">
+          <div id="storyHeader">
+            <span id="storyStepBadge">Step {storyIndex + 1} of {storySteps.length}</span>
+            <h3 id="storyTitle">{storySteps[storyIndex]?.title}</h3>
+          </div>
+          <div id="storyBody" dangerouslySetInnerHTML={{ __html: context ? storySteps[storyIndex].render(context) : "<p>Loading insights…</p>" }} />
+          <div id="storyFooter">
+            <span id="storyScopeLabel">Scope: {context ? context.scopeLabel : "Edo State"}</span>
+            <div>
+              <button id="prevStory" className="storyNavBtn" type="button" disabled={storyIndex === 0} onClick={() => setStoryIndex((idx) => Math.max(0, idx - 1))}>
+                Previous
+              </button>
+              <button id="nextStory" className="storyNavBtn" type="button" disabled={storyIndex === storySteps.length - 1} onClick={() => setStoryIndex((idx) => Math.min(storySteps.length - 1, idx + 1))}>
+                Next insight
+              </button>
+            </div>
+          </div>
+        </section>
+
+        <section id="content-trends">
+          <h3>Poverty profile &amp; time-series</h3>
+          <canvas id="trendChart" ref={trendCanvasRef} />
+        </section>
+
+        <section id="programPanel">
+          <h3>Programme monitoring snapshot</h3>
+          <div id="programSummary">
+            {programSummary.stats ? (
+              <>
+                <p>
+                  <strong>{programSummary.stats.count}</strong> demo programmes currently intersect this view.
+                </p>
+                <p>{programSummary.text}</p>
+                <p>
+                  In production, this panel can be wired to EdoLift’s programme registry to track KPIs, results and SDG 1 contributions in real time.
+                </p>
+              </>
+            ) : (
+              programSummary.text
+            )}
+          </div>
+        </section>
+
+        <section id="africaClockCard">
+          <h3>Africa Poverty Clock – Edo</h3>
+          <p id="africaClockText" dangerouslySetInnerHTML={{ __html: africaClockText }} />
+        </section>
+      </aside>
+
+      <section id="filterPanel" aria-label="Filter poverty view">
+        <label htmlFor="lgaFilter">Scope</label>
+        <select id="lgaFilter" value={pendingFilters.lgaFilter} onChange={(e) => setPendingFilters((prev) => ({ ...prev, lgaFilter: e.target.value }))}>
+          <option value="all">All LGAs</option>
+          {rawRows.map((row) => (
+            <option key={row.lga} value={row.lga}>
+              {row.lga}
+            </option>
+          ))}
+        </select>
+
+        <select id="zoneFilter" value={pendingFilters.zoneFilter} onChange={(e) => setPendingFilters((prev) => ({ ...prev, zoneFilter: e.target.value as Zone | "all" }))}>
+          <option value="all">All zones</option>
+          {zones.map((z) => (
+            <option key={z} value={z}>
+              {z}
+            </option>
+          ))}
+        </select>
+
+        <select id="geoFilter" value={pendingFilters.geoFilter} onChange={(e) => setPendingFilters((prev) => ({ ...prev, geoFilter: e.target.value as Filters["geoFilter"] }))}>
+          <option value="all">Urban &amp; rural</option>
+          <option value="Urban">Urban</option>
+          <option value="Rural">Rural</option>
+        </select>
+
+        <select id="demoFilter" value={pendingFilters.demoFilter} onChange={(e) => setPendingFilters((prev) => ({ ...prev, demoFilter: e.target.value as Filters["demoFilter"] }))}>
+          <option value="all">All genders</option>
+          <option value="females">Females</option>
+          <option value="males">Males</option>
+        </select>
+
+        <label htmlFor="ageMin">Age</label>
+        <input type="number" id="ageMin" min="0" max="100" value={pendingFilters.minAge} onChange={(e) => setPendingFilters((prev) => ({ ...prev, minAge: Number(e.target.value) }))} />
+        <span>–</span>
+        <input type="number" id="ageMax" min="0" max="100" value={pendingFilters.maxAge} onChange={(e) => setPendingFilters((prev) => ({ ...prev, maxAge: Number(e.target.value) }))} />
+
+        <input type="file" id="csvInput" accept=".csv" title="Load CSV" onChange={(e) => e.target.files && e.target.files[0] && handleCsvUpload(e.target.files[0])} />
+
+        <button id="applyFilters" type="button" onClick={handleApplyFilters}>
+          Apply filters
+        </button>
+        <button id="exportCsvBtn" type="button" onClick={exportFilteredCsv}>
+          Export CSV
+        </button>
+        <button id="exportPdfBtn" type="button" onClick={exportPdfBrief}>
+          Export PDF brief
+        </button>
+      </section>
+
+      <div id="methodologyBadge">
+        <strong>EdoLift:</strong> AI-enhanced poverty management system integrating real-time data, forecasts, and programme tracking.
+      </div>
+
+      <div id="aboutModal" className="modalOverlay" role="dialog" aria-modal="true" aria-labelledby="aboutTitle" onClick={(evt) => evt.target === evt.currentTarget && evt.currentTarget.classList.remove("open")}>
+        <div className="modal">
+          <h2 id="aboutTitle">About EdoLift &amp; methodology</h2>
+          <p>
+            EdoLift is a modern, AI-enhanced poverty alleviation management platform for Edo State. It combines real-time monitoring, LGA-level analytics, and predictive modelling through 2030.
+          </p>
+          <p>
+            Data can be ingested from local surveys, national statistics, international datasets and Edo State-specific monitoring systems. Forecasts can be aligned with IMF growth paths and methodologies similar to OECD-style modelling.
+          </p>
+          <p>
+            This prototype supports: real-time poverty counters, LGA heatmaps, poverty profiles, deep dives, scenario-based forecasting, disaggregated views (gender, age, urban/rural), a data explorer, an Africa Poverty Clock lens, and programme monitoring for government, NGOs, donors, philanthropists and the general public.
+          </p>
+          <p>
+            For production deployment, plug an API returning LGA-level poverty metrics and programme data, and document all data sources, computation methods, and limitations in this section.
+          </p>
+          <button type="button" id="closeAbout" onClick={() => document.getElementById("aboutModal")?.classList.remove("open")}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default EdoLiftDashboard;

--- a/apps/bcb-admin/src/reportWebVitals.ts
+++ b/apps/bcb-admin/src/reportWebVitals.ts
@@ -1,4 +1,4 @@
-import { ReportHandler } from "web-vitals";
+type ReportHandler = (...args: unknown[]) => void;
 
 const reportWebVitals = (onPerfEntry?: ReportHandler): void => {
   if (onPerfEntry && onPerfEntry instanceof Function) {

--- a/apps/bcb-admin/src/types/web-vitals.d.ts
+++ b/apps/bcb-admin/src/types/web-vitals.d.ts
@@ -1,0 +1,1 @@
+declare module "web-vitals";


### PR DESCRIPTION
## Summary
- replace the placeholder admin dashboard with the EdoLift poverty intelligence experience converted to React
- implement custom canvas-based charts, map marker rendering, and filterable storyline/programme panels
- add scoped styling and a minimal web-vitals shim to support type-checking

## Testing
- npm run type-check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69241e1a81a88329a38f73cd59a9491d)